### PR TITLE
Fix Image path URL encoding BUG

### DIFF
--- a/lib/blowup.js
+++ b/lib/blowup.js
@@ -98,7 +98,7 @@ $(function ($) {
       $blowupLens.css({
         left                  : lensX,
         top                   : lensY,
-        "background-image"    : "url(" + $IMAGE_URL + ")",
+        "background-image"    : "url(" + encodeURI($IMAGE_URL) + ")",
         "background-size"     : backgroundSize,
         "background-position" : backPos
       });


### PR DESCRIPTION
If Image url include special character like space，background image will not set properly with $blowupLens.css({}).